### PR TITLE
 Fix stripping of [&&NHX]

### DIFF
--- a/nhx_output.cc
+++ b/nhx_output.cc
@@ -43,7 +43,7 @@ static int string_estimate_string_len(const Tree *tree, int out_flag)
 				}
 			}
 			if (p->tree_index) {
-				len += 6; //:T=100
+				len += 6; // ":T=100"
 			}
 			
 		}
@@ -104,7 +104,7 @@ inline int string_nhx_node(char *str, const Tree *t)
 				p += sprintf(p, ":%s=%s", iter->key, iter->val);
 	}
 	p += sprintf(p, "]");
-	if (p - 6 == str) { /* strip [&&NHX] */
+	if (p - 7 == str) { /* strip [&&NHX] */
 		p = str; *str = '\0';
 	}
 	return p - str;


### PR DESCRIPTION
`treebest best` was creating "empty" `[&&NHX]` features in nhx output files, which break downstreaming tools, e.g. ETE3.

To replicate the problem:

```
treebest best -f test_tree.nhx -o output.nhx test_msa.fasta
```

using input files available on:

https://gist.github.com/nsoranzo/4d34e2e3dd7fc3a44157534fa647d64e

which would create the file output.nhx containing a line like this:

```
(ENSOCUT00000008795_Oryctolaguscuniculus:0.060686[&&NHX],
```

After applying this patch, the output line will instead be:

```
(ENSOCUT00000008795_Oryctolaguscuniculus:0.060686,
```